### PR TITLE
fix: check JSON serialization/deserialization is deterministic

### DIFF
--- a/modules/apps/transfer/ibc_module.go
+++ b/modules/apps/transfer/ibc_module.go
@@ -11,6 +11,7 @@ import (
 	capabilitytypes "github.com/cosmos/cosmos-sdk/x/capability/types"
 
 	errorsmod "cosmossdk.io/errors"
+
 	"github.com/cosmos/ibc-go/v6/modules/apps/transfer/keeper"
 	"github.com/cosmos/ibc-go/v6/modules/apps/transfer/types"
 	channeltypes "github.com/cosmos/ibc-go/v6/modules/core/04-channel/types"

--- a/modules/apps/transfer/ibc_module_test.go
+++ b/modules/apps/transfer/ibc_module_test.go
@@ -7,6 +7,7 @@ import (
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	sdkerrors "github.com/cosmos/cosmos-sdk/types/errors"
 	capabilitytypes "github.com/cosmos/cosmos-sdk/x/capability/types"
+
 	"github.com/cosmos/ibc-go/v6/modules/apps/transfer"
 	"github.com/cosmos/ibc-go/v6/modules/apps/transfer/types"
 	channeltypes "github.com/cosmos/ibc-go/v6/modules/core/04-channel/types"


### PR DESCRIPTION
Addresses https://github.com/cosmos/ibc-go/security/advisories/GHSA-jg6f-48ff-5xrw.

## Description

I copied the implementation and unit tests from [this diff](https://github.com/cosmos/ibc-go/compare/v7.8.0...v7.9.2#diff-8ddf47fbc8c8f270342c829d2e405b29d6b4732afeac6dd7ae1c22d5447abd4fR243-R246). The unit tests upstream don't actually cover the implementation change so I added a [test case](https://github.com/celestiaorg/ibc-go/pull/1/files#diff-84e1050545ac3bc948c89e7c6733f8130310338af194e367fa59890ce7796309R378-R390) that does cover it.

cc: @chatton @damiannolan @tac0turtle