### PR TITLE
fix(core/04-channel): check JSON deserialization is deterministic

### DIFF
--- a/modules/core/04-channel/keeper/packet.go
+++ b/modules/core/04-channel/keeper/packet.go
@@ -436,6 +436,15 @@ func (k Keeper) AcknowledgePacket(
 
 	packetCommitment := types.CommitPacket(k.cdc, packet)
 
+	var ack types.Acknowledgement
+	err := types.SubModuleCdc.UnmarshalJSON(acknowledgement, &ack)
+	if err == nil {
+		ackBz := ack.Acknowledgement()
+		if !bytes.Equal(ackBz, acknowledgement) {
+			return sdkerrors.Wrap(types.ErrInvalidAcknowledgement, "acknowledgement marshalling error")
+		}
+	}
+
 	// verify we sent the packet and haven't cleared it out yet
 	if !bytes.Equal(commitment, packetCommitment) {
 		return sdkerrors.Wrapf(types.ErrInvalidPacket, "commitment bytes are not equal: got (%v), expected (%v)", packetCommitment, commitment)

--- a/modules/core/04-channel/keeper/packet_test.go
+++ b/modules/core/04-channel/keeper/packet_test.go
@@ -832,35 +832,35 @@ func (suite *KeeperTestSuite) TestAcknowledgePacket() {
 			suite.chainA.App.GetIBCKeeper().ChannelKeeper.SetNextSequenceAck(suite.chainA.GetContext(), path.EndpointA.ChannelConfig.PortID, path.EndpointA.ChannelID, 10)
 			channelCap = suite.chainA.GetChannelCapability(path.EndpointA.ChannelConfig.PortID, path.EndpointA.ChannelID)
 		}, false},
-		// {
-		// 	"fake acknowledgement",
-		// 	func() {
-		// 		// setup uses an UNORDERED channel
-		// 		suite.coordinator.Setup(path)
+		{
+			"fake acknowledgement",
+			func() {
+				// setup uses an UNORDERED channel
+				suite.coordinator.Setup(path)
 
-		// 		// create packet commitment
-		// 		sequence, err := path.EndpointA.SendPacket(defaultTimeoutHeight, disabledTimeoutTimestamp, ibctesting.MockPacketData)
-		// 		suite.Require().NoError(err)
+				// create packet commitment
+				sequence, err := path.EndpointA.SendPacket(defaultTimeoutHeight, disabledTimeoutTimestamp, ibctesting.MockPacketData)
+				suite.Require().NoError(err)
 
-		// 		channelCap = suite.chainA.GetChannelCapability(path.EndpointA.ChannelConfig.PortID, path.EndpointA.ChannelID)
+				channelCap = suite.chainA.GetChannelCapability(path.EndpointA.ChannelConfig.PortID, path.EndpointA.ChannelID)
 
-		// 		// write packet acknowledgement directly
-		// 		// Create a valid acknowledgement using deterministic serialization.
-		// 		ack = types.NewResultAcknowledgement([]byte{byte(1)}).Acknowledgement()
-		// 		// Introduce non-determinism: insert an extra space after the first character '{'
-		// 		// This will deserialize correctly but fail to re-serialize to the expected bytes.
-		// 		if len(ack) > 0 && ack[0] == '{' {
-		// 			ack = []byte("{ " + string(ack[1:]))
-		// 		}
-		// 		path.EndpointB.Chain.Coordinator.UpdateTimeForChain(path.EndpointB.Chain)
+				// write packet acknowledgement directly
+				// Create a valid acknowledgement using deterministic serialization.
+				ack = types.NewResultAcknowledgement([]byte{byte(1)}).Acknowledgement()
+				// Introduce non-determinism: insert an extra space after the first character '{'
+				// This will deserialize correctly but fail to re-serialize to the expected bytes.
+				if len(ack) > 0 && ack[0] == '{' {
+					ack = []byte("{ " + string(ack[1:]))
+				}
+				path.EndpointB.Chain.Coordinator.UpdateTimeForChain(path.EndpointB.Chain)
 
-		// 		path.EndpointB.Chain.App.GetIBCKeeper().ChannelKeeper.SetPacketAcknowledgement(path.EndpointB.Chain.GetContext(), path.EndpointB.ChannelConfig.PortID, path.EndpointB.ChannelID, sequence, types.CommitAcknowledgement(ack))
+				path.EndpointB.Chain.App.GetIBCKeeper().ChannelKeeper.SetPacketAcknowledgement(path.EndpointB.Chain.GetContext(), path.EndpointB.ChannelConfig.PortID, path.EndpointB.ChannelID, sequence, types.CommitAcknowledgement(ack))
 
-		// 		path.EndpointB.Chain.NextBlock()
-		// 		path.EndpointA.UpdateClient()
-		// 	},
-		// 	false,
-		// },
+				path.EndpointB.Chain.NextBlock()
+				path.EndpointA.UpdateClient()
+			},
+			false,
+		},
 		{
 			"non-standard acknowledgement", func() {
 				// setup uses an UNORDERED channel

--- a/modules/core/04-channel/keeper/packet_test.go
+++ b/modules/core/04-channel/keeper/packet_test.go
@@ -835,6 +835,7 @@ func (suite *KeeperTestSuite) TestAcknowledgePacket() {
 		{
 			"fake acknowledgement",
 			func() {
+				expError = types.ErrInvalidAcknowledgement
 				// setup uses an UNORDERED channel
 				suite.coordinator.Setup(path)
 


### PR DESCRIPTION
Address https://github.com/cosmos/ibc-go/security/advisories/GHSA-4wf3-5qj9-368v by back-porting https://github.com/cosmos/ibc-go/commit/a5b5b929831859be62c5f7dc94970efa868cc84b to v6.x and adding one line to the test to actually verify the expected error for the test case that covers this security vulnerability.

```diff
			"fake acknowledgement",
			func() {
+				expError = types.ErrInvalidAcknowledgement
				// setup uses an UNORDERED channel
				suite.coordinator.Setup(path)
```