### PR TITLE
fix: enable celestia-app to run in Vercel Go runtime  @rootulp

### DIFF
--- a/testing/simapp/app.go
+++ b/testing/simapp/app.go
@@ -2,6 +2,7 @@ package simapp
 
 import (
 	"encoding/json"
+	"fmt"
 	"io"
 	"net/http"
 	"os"
@@ -249,7 +250,9 @@ type SimApp struct {
 func init() {
 	userHomeDir, err := os.UserHomeDir()
 	if err != nil {
-		panic(err)
+		// The user home directory is not available in the Vercel Go runtime so
+		// print a warning and proceed.
+		fmt.Printf("Warning: Error getting user home directory: %v\n", err)
 	}
 
 	DefaultNodeHome = filepath.Join(userHomeDir, ".simapp")


### PR DESCRIPTION
Context: similar to https://github.com/celestiaorg/celestia-app/pull/4428

@lzrscg had to fork this repo to build a celestia-app binary that can run in Vercel Go runtime. If we ignore the error returned by `os.UserHomeDir()` then he doesn't have to use a fork of this repo (and celestia-app). Seems safe to ignore because this is just used for a testing SimApp instance in ibc-go.